### PR TITLE
cleanup example - QC

### DIFF
--- a/modules/QC/main.nf
+++ b/modules/QC/main.nf
@@ -1,15 +1,17 @@
 process FASTQC {
+
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-                    'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0':
-                    'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0' }"
+	'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0':
+	'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0' }"
   
-    tag { "fastqc: ${reads}" }
+    tag { "fastqc: ${sample_id}" }
 
     input:
-    path reads
+    tuple val(sample_id), path(reads) 
     
     output:
-    path "*.zip"
+    tuple val(sample_id), path("${sample_id}*.{html,zip}"), emit: qc_html
+    //path "*.zip"
     
     script:
     """
@@ -20,17 +22,17 @@ process FASTQC {
 process MULTIQC {
 
 	container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-                    'https://depot.galaxyproject.org/singularity/multiqc%3A1.9--py_1':
-                    'quay.io/biocontainers/multiqc:0.9.1a0--py27_0' }"
+       		'https://depot.galaxyproject.org/singularity/multiqc%3A1.9--py_1':
+                'quay.io/biocontainers/multiqc:0.9.1a0--py27_0' }"
 
 	input:
-	path '*'
+	path(dir)
 
 	output:
-	path "*.html", emit: qc_html
+	tuple path("multiqc_data"), path("multiqc_report.html"), emit: qc_html
 
 	script:
 	"""
-	multiqc .
+	multiqc . --force
 	"""
 }

--- a/subworkflows/QC/main.nf
+++ b/subworkflows/QC/main.nf
@@ -1,4 +1,3 @@
-
 // QC subworkflow 
 
 include { FASTQC; MULTIQC  } from '../../modules/QC/'
@@ -6,11 +5,15 @@ include { FASTQC; MULTIQC  } from '../../modules/QC/'
 workflow QC {
 
     take:
-    reads
+    reads // tuple val, path
 
     main:
 	FASTQC_OUT = FASTQC(reads)
- 	MULTIQC_OUT = MULTIQC(FASTQC_OUT.collect())
+	FASTQC_OUT.qc_html
+        	.map { it -> it[1] }
+        	.collect()
+        	.set { fastqc_out }
+ 	MULTIQC_OUT = MULTIQC(fastqc_out)
 	
     emit:
     multiqc_out = MULTIQC_OUT.qc_html


### PR DESCRIPTION
This is an example of clean input with input formatted as a tuple. 
Please, @jadedavis5, take a look at this format. Use val(sample_id) for naming and referring to samples, that makes the pipeline flexible and we can do more operations.
Also: avoid using wildcards in output, which overwrites samples if they are named the same. Let's adopt this practice throughout the pipeline.
